### PR TITLE
Sync Functionality/Updated QRealTime.py

### DIFF
--- a/QRealTime.py
+++ b/QRealTime.py
@@ -288,11 +288,12 @@ class QRealTime:
     def download(self,checked=False):
         if checked==True:
             self.layer= self.getLayer()
-            self.service=self.dlg.getCurrentService()
             forms,response= self.service.getFormList()
             if response:
                 self.formID= forms[self.layer.name()]
-                self.time=int(self.service.getValue(self.tr('sync time')))
+		service=self.dlg.getCurrentService()
+                self.service=service
+                self.time=int(service.getValue(self.tr('sync time')))
                 print('starting timer every'+ str(self.time)+'second')
                 self.timer.start(1000*self.time)
         elif checked==False:


### PR DESCRIPTION
**Bug in Sync function** -Python Error removed

**Python log message**-
Traceback (most recent call last):
              File "C:/Users/hp/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\QRealTime\QRealTime.py", line 295, in download
              self.time=int(self.service.getValue(self.tr('sync time')))
             TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

**Error File**-
![Error File](https://user-images.githubusercontent.com/77684851/109546031-ab9e9000-7aef-11eb-90aa-09cc28156b69.png)

**Corrected File**-
![Corrected File](https://user-images.githubusercontent.com/77684851/109546147-ce30a900-7aef-11eb-81f6-3756378e5af2.png)

